### PR TITLE
fix redis config

### DIFF
--- a/containers/project/lib/rrrspec-config.rb
+++ b/containers/project/lib/rrrspec-config.rb
@@ -1,6 +1,8 @@
+require 'uri'
 RRRSpec.configure do |conf|
   Time.zone_default = Time.find_zone('Asia/Tokyo')
-  conf.redis = { url: ENV['CACHE_PORT'] }
+  url = URI.split(ENV['CACHE_PORT'])
+  conf.redis = {host: url[2], port: url[3]}
 end
 
 RSYNC_REMOTE_PATH = '/opt/rsyncdir'


### PR DESCRIPTION
いつもエントリ参考にさせていただいてます。これも試させてもらったのですが、
redis.newするときのurl指定でtcpスキーマのurlを直接指定できなくなっているので、修正しました（pr投げるほどでもないかもしれないですけど、他に試したい人がいたときにスムーズに動かせるといいなと思ったので……）
あと、本家rrrspecの方にもちょっとだけコケる要素あったので、[pr](https://github.com/cookpad/rrrspec/pull/43)投げてますが、最悪自分でforkしてちょここっと直せば動きますので、参考までに。
